### PR TITLE
remove wierd negative margin rule

### DIFF
--- a/docs/_theme/fedora-bootstrap/static/style.css
+++ b/docs/_theme/fedora-bootstrap/static/style.css
@@ -3,8 +3,3 @@
 .row {
   overflow: hidden;
 }
-
-[class*="col-"]{
-  margin-bottom: -99999px;
-  padding-bottom: 99999px;
-}


### PR DESCRIPTION
This was added when i was playing around with the new theme, and was causing some issues causing content to scroll off the top of pages, and not be able to be scrolled back. There is no need for it, so just removing it.
