### PR TITLE
README: add link to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 This is the git repo for Fedora Cloud docs. It is written in reStructured Text format using sphinx.
+
+These docs are live at https://fedoracloud.readthedocs.io


### PR DESCRIPTION
It would be helpful for folks who stumble across this repo to know
where the docs actually live.